### PR TITLE
Add development Dockerfile for Janitor

### DIFF
--- a/janitor/db.json
+++ b/janitor/db.json
@@ -1,0 +1,39 @@
+{
+  "hostname": "localhost",
+  "ports": {
+    "http": 8081,
+    "https": 8080
+  },
+  "security": {
+    "forceHttp": true,
+    "forceInsecure": true
+  },
+  "mailer": {
+    "block": true,
+    "from": "",
+    "host": "",
+    "auth": {
+      "user": "",
+      "pass": ""
+    }
+  },
+  "hosts": {
+    "localhost": {
+      "properties": {
+        "port": "2376",
+        "ca": "",
+        "crt": "",
+        "key": ""
+      },
+      "oauth2client": {
+        "id": "",
+        "secret": ""
+      }
+    }
+  },
+  "projects": {},
+  "users": {},
+  "admins": {
+    "admin@localhost": true
+  }
+}

--- a/janitor/janitor.dockerfile
+++ b/janitor/janitor.dockerfile
@@ -1,0 +1,15 @@
+FROM janx/ubuntu-dev
+MAINTAINER Jan Keromnes "janx@linux.com"
+
+# Download Janitor's source code and install its dependencies.
+RUN git clone --recursive https://github.com/JanitorTechnology/janitor /home/user/janitor \
+ && cd /home/user/janitor \
+ && npm update
+WORKDIR /home/user/janitor
+
+# Add Janitor database with default values for local development.
+ADD db.json /home/user/janitor/
+RUN sudo chown user:user /home/user/janitor/db.json
+
+# Expose all Janitor server ports.
+EXPOSE 8080 8081

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,16 @@ To build [janx/thunderbird](https://hub.docker.com/r/janx/thunderbird/) yourself
     cd thunderbird
     docker build -t janx/thunderbird -f thunderbird.dockerfile .
 
+## Janitor
+
+    docker run -it --rm janx/janitor /bin/bash
+    user@container:~/janitor (master) $ node app
+
+To build [janx/janitor](https://hub.docker.com/r/janx/janitor/) yourself:
+
+    cd janitor
+    docker build -t janx/janitor -f janitor.dockerfile .
+
 # More Dockerfiles
 
 There are other great development Dockerfiles out there:


### PR DESCRIPTION
This should allow us to [Put The Janitor in The Janitor](https://github.com/JanitorTechnology/janitor/issues/31) 🎉🎈🍕🍾

Not tested yet, and to work properly out-of-the-box it also depends on an upcoming Janitor commit (titled "Allow forcing insecure HTTP for local development only").