### PR TITLE
[ubuntu-dev] install locales for all images

### DIFF
--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update -q \
   libnotify-bin \
   libssl-dev \
   lld-4.0 \
+  locales \
   mercurial \
   nano \
   neovim \


### PR DESCRIPTION
The Chromium build currently fails on CircleCI, and it shows this error:

> Installing locales.
> sudo: locale-gen: command not found
> The command '/bin/sh -c echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections  && sudo src/build/install-build-deps.sh --no-prompt --no-arm --no-chromeos-fonts --no-nacl' returned a non-zero code: 1
> Exited with code 1

I believe that simply installing the Ubuntu package `locales` will fix that.