### PR TITLE
[all] use docker layer cache to optimize circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,10 @@ jobs:
       - run:
           command: |
             cd ubuntu-dev
-            docker build -t janx/ubuntu-dev:latest -f ubuntu-dev.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker push janx/ubuntu-dev:latest
+            docker pull janx/ubuntu-dev
+            docker build --cache-from=janx/ubuntu-dev -t janx/ubuntu-dev -f ubuntu-dev.dockerfile .
+            docker push janx/ubuntu-dev
 
   chromium:
     docker:
@@ -24,8 +25,9 @@ jobs:
       - run:
           command: |
             cd chromium
-            docker build -t janx/chromium:base -f chromium.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/chromium:base
+            docker build --cache-from=janx/chromium:base -t janx/chromium:base -f chromium.dockerfile .
             docker push janx/chromium:base
           no_output_timeout: 90m
 
@@ -38,8 +40,9 @@ jobs:
       - run:
           command: |
             cd firefox
-            docker build -t janx/firefox:base -f firefox-git.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/firefox:base
+            docker build --cache-from=janx/firefox:base -t janx/firefox:base -f firefox-git.dockerfile .
             docker push janx/firefox:base
           no_output_timeout: 30m
 
@@ -52,8 +55,9 @@ jobs:
       - run:
           command: |
             cd firefox
-            docker build -t janx/firefox-hg:base -f firefox-hg.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/firefox-hg:base
+            docker build --cache-from=janx/firefox-hg:base -t janx/firefox-hg:base -f firefox-hg.dockerfile .
             docker push janx/firefox-hg:base
           no_output_timeout: 30m
 
@@ -66,8 +70,9 @@ jobs:
       - run:
           command: |
             cd janitor
-            docker build -t janx/janitor:base -f janitor.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/janitor:base
+            docker build --cache-from=janx/janitor:base -t janx/janitor:base -f janitor.dockerfile .
             docker push janx/janitor:base
 
   servo:
@@ -79,8 +84,9 @@ jobs:
       - run:
           command: |
             cd servo
-            docker build -t janx/servo:base -f servo.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/servo:base
+            docker build --cache-from=janx/servo:base -t janx/servo:base -f servo.dockerfile .
             docker push janx/servo:base
           no_output_timeout: 30m
 
@@ -93,8 +99,9 @@ jobs:
       - run:
           command: |
             cd thunderbird
-            docker build -t janx/thunderbird:base -f thunderbird.dockerfile .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/thunderbird:base
+            docker build --cache-from=janx/thunderbird:base -t janx/thunderbird:base -f thunderbird.dockerfile .
             docker push janx/thunderbird:base
           no_output_timeout: 30m
 

--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -113,8 +113,8 @@ RUN mkdir /tmp/hub \
 RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
 
 # Install latest Node.js, npm and Yarn.
-RUN nvm install node \
- && nvm use node \
+RUN . /home/user/.nvm/nvm.sh \
+ && nvm install node \
  && npm install -g yarn
 
 # Install the latest rr.


### PR DESCRIPTION
This change makes CircleCI pull all Docker images from Docker Hub before re-building them in order to re-use their cached layers where possible. This should make image updates both faster and smaller.

Another option would be to cache image layers locally in CircleCI, as shown in this [blog post](https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/#build-and-cache-docker-images).