### PR TITLE
[janitor] use docker hub automated builds instead of circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,20 +61,6 @@ jobs:
             docker push janx/firefox-hg:base
           no_output_timeout: 30m
 
-  janitor:
-    docker:
-      - image: docker:stable
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          command: |
-            cd janitor
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker pull janx/ubuntu-dev
-            docker build -t janx/janitor:base -f janitor.dockerfile .
-            docker push janx/janitor:base
-
   servo:
     docker:
       - image: docker:stable
@@ -120,9 +106,6 @@ workflows:
           requires:
             - ubuntu-dev
       - firefox-hg:
-          requires:
-            - ubuntu-dev
-      - janitor:
           requires:
             - ubuntu-dev
       - servo:

--- a/janitor/janitor-update.dockerfile
+++ b/janitor/janitor-update.dockerfile
@@ -1,4 +1,4 @@
-FROM janx/janitor
+FROM janitortechnology/janitor
 MAINTAINER Jan Keromnes "janx@linux.com"
 
 # Upgrade all packages.

--- a/readme.md
+++ b/readme.md
@@ -65,13 +65,13 @@ To build [janx/thunderbird](https://hub.docker.com/r/janx/thunderbird/) yourself
 
 ## Janitor
 
-    docker run -it --rm janx/janitor /bin/bash
+    docker run -it --rm janitortechnology/janitor /bin/bash
     user@container:~/janitor (master) $ node app
 
-To build [janx/janitor](https://hub.docker.com/r/janx/janitor/) yourself:
+To build [janitortechnology/janitor](https://hub.docker.com/r/janitortechnology/janitor/) yourself:
 
     cd janitor
-    docker build -t janx/janitor -f janitor.dockerfile .
+    docker build -t janitortechnology/janitor -f janitor.dockerfile .
 
 # More Dockerfiles
 


### PR DESCRIPTION
Docker Hub automated builds are easier to set up, and seem to be more useful for small projects like Janitor.

You just need to go to Docker Hub, create a new "automated build", point it to your repository and dockerfile, and voilà. (Additionally, you can set it up to also rebuild on pushes to other images, e.g. `janx/ubuntu-dev`.)

I think this could become the official way to add new projects to Janitor.