### PR TITLE
[ubuntu-dev] increase c9sdk code editor font size to 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             docker pull janx/ubuntu-dev
             docker build -t janx/chromium -f chromium.dockerfile .
             docker push janx/chromium
-          no_output_timeout: 90m
+          no_output_timeout: 8h
 
   firefox-git:
     docker:

--- a/ubuntu-dev/workspace-janitor.js
+++ b/ubuntu-dev/workspace-janitor.js
@@ -62,6 +62,9 @@ module.exports = function (options) {
           // Use the Monokai theme by default.
           p.settings.user.ace['@theme'] = 'ace/theme/monokai';
 
+          // Use a bigger code editor font size by default.
+          p.settings.user.ace['@fontSize'] = '14';
+
           if (!p.settings.user.terminal) {
             p.settings.user.terminal = {};
           }


### PR DESCRIPTION
In this pull request, I increase the default code editor font size in Cloud9 SDK from 12 to 14 (it's more comfortable for coding, and still shows a lot of code even on small screens. It's the font size already used in the Terminal).

I also wanted to change the default indentation from 4 to 2, and to enable "remove trailing spaces on save" by default, but I couldn't find these settings in `p.settings.user`. Maybe they're elsewhere?

Also: I sneak in a change in Chromium's `no_output_timeout` variable, in an attempt to work around the 5 hours build limit on CircleCI. Fingers crossed.