### PR TITLE
[ubuntu-dev] enable c9sdk browser caching for all images

### DIFF
--- a/ubuntu-dev/supervisord.conf
+++ b/ubuntu-dev/supervisord.conf
@@ -7,7 +7,7 @@ user = user
 command = sudo /usr/sbin/sshd -D
 [program:c9sdk]
 user = user
-command = /home/user/.c9sdk/server.js --auth : --listen 0.0.0.0 --packed --port 8089 --workspacetype=janitor -w /home/user
+command = /home/user/.c9sdk/server.js --auth : --listen 0.0.0.0 --packed --port 8089 --useBrowserCache --workspacetype=janitor -w /home/user
 [program:xvfb]
 user = user
 command = /usr/bin/Xvfb :98 -screen 0 1280x864x16 -ac -pn -noreset


### PR DESCRIPTION
More details on `--useBrowserCache` feature in this [Cloud9 SDK email thread](https://groups.google.com/forum/#!topic/cloud9-sdk/F-ksHqHhMUM).