### PR TITLE
[ubuntu-dev] force pip to use python 2.7 and not python 3+

### DIFF
--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -61,6 +61,7 @@ RUN __LLVM_VERSION__="5.0" \
  && pip install --upgrade pip \
  && pip install --upgrade virtualenv \
  && pip3 install --upgrade pip \
+ && cp /usr/local/bin/pip2 /usr/local/bin/pip \
  && echo "SHELL=/bin/bash\nTERM=xterm-256color\nDISPLAY=:98\nCC=clang-${__LLVM_VERSION__}\nCXX=clang++-${__LLVM_VERSION__}" >> /etc/environment
 ENV SHELL /bin/bash
 ENV CC clang-5.0


### PR DESCRIPTION
This is terrible. Please suggest a better solution if you know one.