### PR TITLE
Enable codeintel in the IDE

### DIFF
--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -201,6 +201,22 @@ RUN git clone https://github.com/kanaka/noVNC /home/user/.novnc/ \
  && cd /home/user/.novnc \
  && npm install \
  && node ./utils/use_require.js --as commonjs --with-app
+ 
+# Install dependencies to enable codeintel (https://github.com/c9/c9.ide.language.codeintel)
+RUN easy_install pip
+ && pip install -U pip
+ && pip install -U virtualenv
+ && virtualenv --python=python2 $HOME/.c9/python2
+ && source $HOME/.c9/python2/bin/activate
+ && apt-get update
+ && apt-get install python-dev
+ && mkdir /tmp/codeintel
+ && pip download -d /tmp/codeintel codeintel==0.9.3
+ && cd /tmp/codeintel
+ && tar xf CodeIntel-0.9.3.tar.gz
+ && mv CodeIntel-0.9.3/SilverCity CodeIntel-0.9.3/silvercity
+ && tar czf CodeIntel-0.9.3.tar.gz CodeIntel-0.9.3
+ && pip install -U --no-index --find-links=/tmp/codeintel codeintel
 
 # Install the latest Cloud9 SDK with some useful IDE plugins.
 RUN git clone https://github.com/c9/core.git /home/user/.c9sdk \

--- a/ubuntu-dev/workspace-janitor.js
+++ b/ubuntu-dev/workspace-janitor.js
@@ -71,6 +71,21 @@ module.exports = function (options) {
 
           // Use a longer scrollback for the Terminal.
           p.settings.user.terminal['@scrollback'] = 10000;
+
+          if (!p.settings.project) {
+            p.settings.user = {};
+          }
+
+          if (typeof p.settings.project === 'string') {
+            p.settings.project = JSON.parse(p.settings.project);
+          }
+
+          if (!p.settings.project.codeintel) {
+            p.settings.user.codeintel = {};
+          }
+
+          // Dismiss the codeintel popup because it's installed
+          p.settings.project.codeintel['@dismiss_installer'] = true;
         }
         break;
     }


### PR DESCRIPTION
I experienced a popup in the IDE asking if I wanted to install and enable codeintel.
This PR is based on https://github.com/c9/c9.ide.language.codeintel and on https://github.com/c9/c9.ide.language.codeintel/blob/435e0840663ee5e7fecaabfd3daa865eb2113e4c/codeintel.js#L149.