### PR TITLE
[chromium][firefox][servo][thunderbird] tweak janitor.json scripts

### DIFF
--- a/chromium/janitor.json
+++ b/chromium/janitor.json
@@ -21,12 +21,12 @@
     }
   },
   "scripts": {
-    "Build (ninja -C out/Default chrome)": "ninja -C out/Default chrome",
-    "Run (out/Default/chrome --no-sandbox)": {
+    "Build Chromium": "ninja -C out/Default chrome",
+    "Run Chromium": {
       "cmd": "out/Default/chrome --no-sandbox",
       "openPort": "8088"
     },
-    "Update source code (git rebase-update && gclient sync)": "git rebase-update && gclient sync",
-    "Send to code review (git cl upload)": "git cl upload"
+    "Update source code": "git rebase-update && gclient sync",
+    "Send to code review": "git cl upload"
   }
 }

--- a/firefox/janitor-git.json
+++ b/firefox/janitor-git.json
@@ -21,14 +21,14 @@
     }
   },
   "scripts": {
-    "./mach build": "./mach build",
-    "./mach build faster": "./mach build faster",
-    "./mach build binaries": "./mach build binaries",
-    "./mach run": {
+    "Build Firefox": "./mach build",
+    "Build faster": "./mach build faster",
+    "Build binaries": "./mach build binaries",
+    "Run Firefox": {
       "cmd": "./mach run",
       "openPort": "8088"
     },
-    "./mach clobber": "./mach clobber",
+    "Clobber build": "./mach clobber",
     "Update source code": "git fetch origin && git rebase origin/master",
     "Send to code review": "git bz attach -e origin/master..HEAD"
   }

--- a/firefox/janitor-hg.json
+++ b/firefox/janitor-hg.json
@@ -21,14 +21,14 @@
     }
   },
   "scripts": {
-    "./mach build": "./mach build",
-    "./mach build faster": "./mach build faster",
-    "./mach build binaries": "./mach build binaries",
-    "./mach run": {
+    "Build Firefox": "./mach build",
+    "Build faster": "./mach build faster",
+    "Build binaries": "./mach build binaries",
+    "Run Firefox": {
       "cmd": "./mach run",
       "openPort": "8088"
     },
-    "./mach clobber": "./mach clobber",
+    "Clobber build": "./mach clobber",
     "Update source code": "hg pull -u",
     "Send to code review": "hg push review"
   }

--- a/servo/janitor.json
+++ b/servo/janitor.json
@@ -21,17 +21,17 @@
     }
   },
   "scripts": {
-    "./mach build --dev": "./mach build --dev",
-    "./mach build --release": "./mach build --release",
-    "./mach run --dev": {
+    "Build Servo (dev)": "./mach build --dev",
+    "Build Servo (release)": "./mach build --release",
+    "Run Servo (dev)": {
       "cmd": "./mach run --dev",
       "openPort": "8088"
     },
-    "./mach run --release": {
+    "Run Servo (release)": {
       "cmd": "./mach run --release",
       "openPort": "8088"
     },
-    "./mach check": "./mach check",
+    "Check coding style": "./mach check",
     "Update source code": "git fetch origin && git rebase origin/master",
     "Send to code review": "hub pull-request"
   }

--- a/thunderbird/janitor.json
+++ b/thunderbird/janitor.json
@@ -21,13 +21,13 @@
     }
   },
   "scripts": {
-    "./mozilla/mach build": "./mozilla/mach build",
-    "make -C objdir/calendar/lightning": "make -C objdir/calendar/lightning",
-    "./mozilla/mach run": {
+    "Build Thunderbird": "./mozilla/mach build",
+    "Build Lightning": "make -C objdir/calendar/lightning",
+    "Run Thunderbird": {
       "cmd": "./mozilla/mach run",
       "openPort": "8088"
     },
-    "./mozilla/mach clobber": "./mozilla/mach clobber",
+    "Clobber build": "./mozilla/mach clobber",
     "Update sources": "python client.py checkout"
   }
 }


### PR DESCRIPTION
Now that we repeat explicit commands between `()` in c9runner names, we can make the actual script names more descriptive.