### PR TITLE
Re-add mkdir command to fix permission issue

### DIFF
--- a/chromium/chromium.dockerfile
+++ b/chromium/chromium.dockerfile
@@ -18,6 +18,7 @@ RUN echo "\n# Disable gyp_chromium for faster updates." >> .bashrc \
  && echo "export GYP_CHROMIUM_NO_ACTION=1" >> .bashrc
 
 # Create the Chromium directory.
+RUN mkdir /home/user/chromium
 WORKDIR /home/user/chromium
 
 # Download Chromium's source code.


### PR DESCRIPTION
It turns out WORKDIR executes commands as `root`. Since we we need to create a `.gclient` file later, we need to use `RUN mkdir` before.

An alternative would be to change user to `root`.

R: @jankeromnes  