### PR TITLE
[fennec] automatically build and push docker image with circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,21 @@ jobs:
             docker push janx/chromium
           no_output_timeout: 90m
 
+  fennec:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: |
+            cd fennec
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker pull janx/ubuntu-dev
+            docker build -t janitortechnology/fennec -f fennec.dockerfile .
+            docker push janitortechnology/fennec
+          no_output_timeout: 30m
+
   firefox-git:
     docker:
       - image: docker:stable

--- a/readme.md
+++ b/readme.md
@@ -5,11 +5,11 @@
 
 Popular development environments as Docker containers.
 
-All images are available on Docker Hub (under [/janx/](https://hub.docker.com/u/janx/) or [/janitortechnology/](https://hub.docker.com/u/janitortechnology/)).
+All images are available on Docker Hub under [/janitortechnology/](https://hub.docker.com/u/janitortechnology/) (previously under [/janx/](https://hub.docker.com/u/janx/)).
 
 ## Ubuntu-dev
 
-Most images here are based on `janx/ubuntu-dev`, which is basically `ubuntu:16.04` with:
+Most images here are based on `ubuntu-dev`, which is basically `ubuntu:16.04` with:
 
 - Useful packages like `clang`, `git`, `vim`…
 - A `user` which can `sudo`
@@ -31,6 +31,16 @@ To build [janx/chromium](https://hub.docker.com/r/janx/chromium/) yourself:
     cd chromium
     docker build -t janx/chromium -f chromium.dockerfile .
 
+## Discourse
+
+    docker run -it --rm janitortechnology/discourse /bin/bash
+    user@container:~/discourse (master) $ bundle exec rspec
+
+To build [janitortechnology/discourse](https://hub.docker.com/r/janitortechnology/discourse/) yourself:
+
+    cd discourse
+    docker build -t janitortechnology/discourse -f discourse.dockerfile .
+
 ## Firefox
 
     docker run -it --rm janx/firefox /bin/bash
@@ -44,7 +54,7 @@ To build [janx/firefox](https://hub.docker.com/r/janx/firefox/) yourself:
 Or for a Firefox image that uses Mercurial (`hg`) instead of Git:
 
     cd firefox
-    docker build -t janx/firefox -f firefox-hg.dockerfile .
+    docker build -t janx/firefox-hg -f firefox-hg.dockerfile .
 
 ## Servo
 

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,16 @@ Or for a Firefox image that uses Mercurial (`hg`) instead of Git:
     cd firefox
     docker build -t janx/firefox-hg -f firefox-hg.dockerfile .
 
+## Firefox for Android (Fennec)
+
+    docker run -it --rm janitortechnology/fennec /bin/bash
+    user@container:~/fennec (master) $ ./mach build
+
+To build [janitortechnology/fennec](https://hub.docker.com/r/janitortechnology/fennec/) yourself:
+
+    cd fennec
+    docker build -t janitortechnology/fennec -f fennec.dockerfile .
+
 ## Servo
 
     docker run -it --rm janx/servo /bin/bash


### PR DESCRIPTION
A follow-up to #146 that adds Fennec to our Circle CI manifest in order to automate its build & deployment.