### PR TITLE
[fennec] automatically build and push docker image with circleci 2/2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,9 @@ workflows:
       - chromium:
           requires:
             - ubuntu-dev
+      - fennec:
+          requires:
+            - ubuntu-dev
       - firefox-git:
           requires:
             - ubuntu-dev


### PR DESCRIPTION
Follow-up to #147, where I added a `fennec` Circle CI job, but forgot to add it to the `build-and-deploy` automated workflow.