### PR TITLE
[ubuntu-dev] Install typescript globally

### DIFF
--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -230,6 +230,9 @@ RUN cd /home/user/.theia/ \
  && yarn \
  && yarn theia build
 
+# Configure language server executable for Theia.
+ENV CPP_CLANGD_COMMAND clangd-6.0
+
 # Install TypeScript globally to provide a language server fallback.
 RUN npm install -g typescript
 

--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -230,6 +230,9 @@ RUN cd /home/user/.theia/ \
  && yarn \
  && yarn theia build
 
+# Install TypeScript globally to provide a language server fallback.
+RUN npm install -g typescript
+
 # Add default Supervisor configuration.
 ADD supervisord.conf /etc/
 


### PR DESCRIPTION
It may be unacceptable for pure JS project to have TS as a devDependency, so we should have a fallback in the case.