### PR TITLE
Fix Theia incompatibility

### DIFF
--- a/ubuntu-dev/theia/package.json
+++ b/ubuntu-dev/theia/package.json
@@ -24,7 +24,6 @@
         "@theia/terminal": "next",
         "@theia/typescript": "next",
         "@theia/userstorage": "next",
-        "theia-yang-extension": "latest",
         "@theia/search-in-workspace": "next"
     },
     "devDependencies": {


### PR DESCRIPTION
This extension seems to have different release cycle and probably has posed compatibility issues. Removing allowed Theia to boot.