### PR TITLE
Chromium: use a faster preset

### DIFF
--- a/chromium/chromium.dockerfile
+++ b/chromium/chromium.dockerfile
@@ -42,7 +42,7 @@ WORKDIR /home/user/chromium/src
 RUN gclient runhooks --jobs=`nproc`
 
 # Configure Chromium build.
-RUN gn gen out/Default --args="enable_nacl=false is_component_build=true"
+RUN gn gen out/Default --args="enable_nacl=false is_component_build=true use_jumbo_build=true symbol_level=1"
 
 # Configure Janitor for Chromium
 COPY janitor.json /home/user/


### PR DESCRIPTION
With this preset build is 3x faster (3h -> 1h) and artifacts takes 1/4 space (26GiB -> 6GiB).

Jumbo: in general this is good for build speed. Slightly makes rebuild slower.

Reduced debug level: the debug information is function only as opposed to line-level. This may make debug harder but in general it's not a critical drawback.

Documents: https://chromium.googlesource.com/chromium/src/+/lkcr/docs/linux_build_instructions.md#faster-builds