### PR TITLE
[fennec] fix build by re-enabling official branding

### DIFF
--- a/fennec/mozconfig
+++ b/fennec/mozconfig
@@ -1,6 +1,6 @@
 # Build Firefox for Android (Fennec):
 ac_add_options --enable-application=mobile/android
-#ac_add_options --enable-official-branding
+ac_add_options --enable-official-branding
 ac_add_options --with-ccache
 #ac_add_options --target=arm-linux-androideabi
 ac_add_options --target=i386-linux-android


### PR DESCRIPTION
Unofficial builds use something like `fennec_${USER}` as the package name, and apparently
this causes us to use an invalid package name. Re-enabling official branding should fix it.