### PR TITLE
adding PrivateBin to Janitor

### DIFF
--- a/privatebin/.dockerignore
+++ b/privatebin/.dockerignore
@@ -1,0 +1,1 @@
+*.dockerfile

--- a/privatebin/janitor.json
+++ b/privatebin/janitor.json
@@ -1,0 +1,38 @@
+{
+  "name": "PrivateBin",
+  "description": "PrivateBin is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted and decrypted in the browser using 256bit AES in Galois Counter mode.",
+  "icon": "https://janitor.technology/img/privatebin.svg",
+  "docker": {
+    "image": "janitortechnology/privatebin"
+  },
+  "ports": {
+    "22": {
+      "label": "SSH",
+      "proxy": "none"
+    },
+    "80": {
+      "label": "PrivateBin",
+      "proxy": "https",
+      "preview": true
+    },
+    "8088": {
+      "label": "VNC",
+      "proxy": "https"
+    },
+    "8089": {
+      "label": "Cloud9",
+      "proxy": "https"
+    },
+    "8090": {
+      "label": "Theia",
+      "proxy": "https"
+    }
+  },
+  "scripts": {
+    "Run all (phpunit & mocha) tests": "unit-test",
+    "Run frontend (mocha) tests": "cd /home/user/privatebin/js && mocha",
+    "Run backend (phpunit) tests": "cd /home/user/privatebin/tst && phpunit",
+    "Update source code": "git pull --rebase origin master",
+    "Send to code review": "hub pull-request"
+  }
+}

--- a/privatebin/nginx-site.conf
+++ b/privatebin/nginx-site.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80 default_server;
+
+    root /home/user/privatebin;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        include /etc/nginx/location.d/*.conf;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+
+        # Prevent exposing nginx + version to $_SERVER
+        fastcgi_param SERVER_SOFTWARE "";
+    }
+}

--- a/privatebin/privatebin-update.dockerfile
+++ b/privatebin/privatebin-update.dockerfile
@@ -1,0 +1,12 @@
+FROM janitortechnology/privatebin
+MAINTAINER PrivateBin <support@privatebin.org>
+
+# Upgrade all packages
+RUN sudo apt-get update -q && \
+    sudo apt-get upgrade -qy && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/user/privatebin
+
+# Update PrivateBin
+RUN git pull --rebase origin master

--- a/privatebin/privatebin.dockerfile
+++ b/privatebin/privatebin.dockerfile
@@ -1,0 +1,42 @@
+FROM janitortechnology/ubuntu-dev
+MAINTAINER PrivateBin <support@privatebin.org>
+
+# Download deps
+RUN sudo apt-get update && \
+    sudo apt-get -y install --no-install-recommends nginx php-fpm php-gd php-sqlite3 phpunit && \
+    npm install -g mocha jsverify jsdom@9 jsdom-global@2 mime-types && \
+
+# Configure php-fpm
+    sudo mkdir -p /run/php && \
+    sudo sed -ri "s/^;daemonize = .*$/daemonize = no/" /etc/php/7.0/fpm/php-fpm.conf && \
+    sudo sed -ri "s/^(user|group) = .*$/\1 = user/" /etc/php/7.0/fpm/pool.d/www.conf && \
+
+# Configure supervisord
+    sudo sh -c "echo '[program:php-fpm]\n\
+user = user\n\
+command = sudo /usr/sbin/php-fpm7.0\n\
+autorestart = true\n\
+[program:nginx]\n\
+user = user\n\
+command = sudo /usr/sbin/nginx -g \"daemon off;\"\n\
+autorestart = true' >> /etc/supervisord.conf" && \
+
+# Prepare Git repository & clean up
+    git clone https://github.com/PrivateBin/PrivateBin /home/user/privatebin && \
+    ln -s $(npm config get prefix)/lib/node_modules /home/user/node_modules && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# Deploy unit test wrapper script & nginx configuration
+COPY unit-test.sh /usr/local/bin/unit-test
+COPY nginx-site.conf /etc/nginx/sites-available/default
+
+WORKDIR /home/user/privatebin
+
+# Configure the IDEs to use PrivateBin's source directory as workspace.
+ENV WORKSPACE /home/user/privatebin/
+
+# Nginx port
+EXPOSE 80
+
+# Configure Janitor for PrivateBin
+COPY janitor.json /home/user/

--- a/privatebin/unit-test.sh
+++ b/privatebin/unit-test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+MOCHA_LOG=$(mktemp mocha_XXXXXX.log)
+
+# run mocha (in background)
+cd /home/user/privatebin/js && mocha 2> "$MOCHA_LOG" > "$MOCHA_LOG" &
+
+# run phpunit (in foreground)
+cd /home/user/privatebin/tst && phpunit
+
+# present mocha results, when done
+echo
+wait
+cat "$MOCHA_LOG"
+rm "$MOCHA_LOG"
+

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,16 @@ To build [janitortechnology/janitor](https://hub.docker.com/r/janitortechnology/
     cd janitor
     docker build -t janitortechnology/janitor -f janitor.dockerfile .
 
+## PrivateBin
+
+    docker run -it --rm janitortechnology/privatebin /bin/bash
+    user@container:~/janitor (master) $ unit-test
+
+To build [janitortechnology/privatebin](https://hub.docker.com/r/janitortechnology/privatebin/) yourself:
+
+    cd privatebin
+    docker build -t janitortechnology/privatebin -f privatebin.dockerfile .
+
 # More Dockerfiles
 
 There are other great development Dockerfiles out there:


### PR DESCRIPTION
Hello @jankeromnes 

I finally found time to put together a Janitor image for PrivateBin, as outlined in the [Janitor community](https://discourse.janitor.technology/t/how-to-add-a-project/165).

PrivateBin is a PHP & JS web application. While it is simple to set up, we always had complaints (even among the core developers) that the unit testing setup was to complex and therefore many errors only get caught in our pull request triggered travis CI runs and subsequently have to be fixed by other developers, since the requester can't run the test locally.

I really like the idea of Janitor, as a way to provide less savvy contributors an easy way to pop up a PrivateBin development environment, do their changes, run the tests and then create their pull requests.

The container image adds a nginx + php-fpm setup exposing the Git repository, so one can instantly review the result of any changes in the browser. I am not sure if all the GUI stuff is needed for Janitor or not. If you like I can work on a slimmer container that doesn't include VNC etc. For PrivateBin the WebIDEs (which include a terminal to run tests) and the nginx server should be sufficient.

I did build and test the container locally. My application for a Janitor account sent back in March was not yet approved. I'll be glad to test the container in Janitor once I get my account.

For the [SVG logo](https://github.com/JanitorTechnology/janitor/tree/master/static/img) I would propose our [icon.svg from our assets](https://github.com/PrivateBin/assets/blob/master/images/svgs/icon.svg). Should I do a separate pull request for that?

Kind Regards
El RIDO