### PR TITLE
 [ubuntu-dev] bump supervisor startsecs from 1 to 5 for fragile x11vnc process

### DIFF
--- a/ubuntu-dev/supervisord.conf
+++ b/ubuntu-dev/supervisord.conf
@@ -20,6 +20,7 @@ command = /usr/bin/Xvfb :98 -screen 0 1280x864x16 -ac -pn -noreset
 user = user
 command = x11vnc -shared -rfbport 5900 -display :98
 autorestart = true
+startsecs = 5
 [program:novnc]
 user = user
 command = /home/user/.novnc/utils/launch.sh --listen 8088 --vnc localhost:5900 --web /home/user/.novnc/build

--- a/ubuntu-dev/supervisord.conf
+++ b/ubuntu-dev/supervisord.conf
@@ -2,6 +2,7 @@
 nodaemon = true
 logfile = /tmp/supervisord.log
 pidfile = /tmp/supervisord.pid
+[supervisorctl]
 [program:sshd]
 user = user
 command = sudo /usr/sbin/sshd -D


### PR DESCRIPTION
In some containers x11vnc stays alive for just over a second and then dies.
Repeatedly. This fix should save us a lot of unnecessary compute and logs.