### PR TITLE
Use upper-case letter 'f' for foundation

### DIFF
--- a/thunderbird/janitor.json
+++ b/thunderbird/janitor.json
@@ -1,6 +1,6 @@
 {
   "name": "Thunderbird",
-  "description": "The email client by Mozilla foundation.",
+  "description": "The email client by Mozilla Foundation.",
   "icon": "https://janitor.technology/img/thunderbird.svg",
   "docker": {
     "image": "janitortechnology/thunderbird"


### PR DESCRIPTION
Mozilla writes Mozilla Foundation with an upper-case 'f' on the website. Let's keep things consistent. :)